### PR TITLE
Passing classifying vars and keys on as parameters.

### DIFF
--- a/src/pystatis/table.py
+++ b/src/pystatis/table.py
@@ -41,6 +41,12 @@ class Table:
         stand: str = "",
         language: str = "de",
         quality: str = "off",
+        classifyingvariable1: str = "",
+        classifyingkey1: str = "",
+        classifyingvariable2: str = "",
+        classifyingkey2: str = "",
+        classifyingvariable3: str = "",
+        classifyingkey3: str = "",
     ) -> None:
         """Downloads raw data and metadata from GENESIS-Online.
 
@@ -141,6 +147,19 @@ class Table:
             "quality": quality,
             "format": "ffcsv",
         }
+
+        if classifyingvariable1:
+            params['classifyingvariable1'] = classifyingvariable1
+        if classifyingkey1:
+            params['classifyingkey1'] = classifyingkey1
+        if classifyingvariable2:
+            params['classifyingvariable2'] = classifyingvariable2
+        if classifyingkey2:
+            params['classifyingkey2'] = classifyingkey2
+        if classifyingvariable3:
+            params['classifyingvariable3'] = classifyingvariable3
+        if classifyingkey3:
+            params['classifyingkey3'] = classifyingkey3
 
         db_matches = db.identify_db_matches(self.name)
         db_name = db.select_db_by_credentials(db_matches)


### PR DESCRIPTION
Passing the classifying variables and keys as arguments to the `Table.get_data()` function no longer works. The changes in this PR add this option back.

Here is an example:
```
from pystatis import Table

t = Table(name='51000-0014')
t.get_data(startyear=2019, endyear=2024, classifyingvariable1='WAM8', classifyingkey1='WA28141000,WA28142000')
```

This used to work in previous versions of pystatis, it stopped working at some point, and this PR tries to bring back that functionality.

This is related to issue #157.