### PR TITLE
feat(config): allow setup_credentials() to configure only a subset of databases

### DIFF
--- a/src/pystatis/config.py
+++ b/src/pystatis/config.py
@@ -151,12 +151,25 @@ def config_exists() -> bool:
     return config_file.exists()
 
 
-def setup_credentials() -> None:
-    """Setup credentials for all supported databases."""
-    for db_name in get_supported_db():
+def setup_credentials(db_names: list[str] | None = None, *, validate: bool = True) -> None:
+    """Setup credentials for one or more supported databases."""
+    supported = get_supported_db()
+    targets = supported if db_names is None else db_names
+
+    unknown = [name for name in targets if name not in supported]
+    if unknown:
+        raise PystatisConfigError(
+            f"Unknown database(s): {', '.join(unknown)}. Supported: {', '.join(supported)}"
+        )
+
+    for db_name in targets:
+        if not config.has_section(db_name):
+            config.add_section(db_name)
+
         config.set(db_name, "username", _get_user_input(db_name, "username"))
         config.set(db_name, "password", _get_user_input(db_name, "password"))
-        if not db.check_credentials_are_valid(db_name):
+
+        if validate and not db.check_credentials_are_valid(db_name):
             raise PystatisConfigError(
                 f"Provided credentials for database '{db_name}' are not valid! Please provide the correct credentials."
             )
@@ -164,7 +177,8 @@ def setup_credentials() -> None:
     write_config()
 
     logger.info(
-        "Config was updated with latest credentials. Path: %s.",
+        "Config was updated with latest credentials for: %s. Path: %s.",
+        ", ".join(targets),
         _build_config_file_path(),
     )
 


### PR DESCRIPTION
**Summary**

* Adds a `db_names: list[str] | None = None` parameter (and `validate: bool = True`) to `setup_credentials()`.
* When `db_names` is provided (e.g., `["genesis"]`), only those databases are prompted/read from env and (optionally) validated.
* Default behavior is unchanged: calling `setup_credentials()` with no arguments still configures **all** supported databases.
* Leaves non-targeted sections in `config.ini` untouched.

**Motivation / Problem**

* Users frequently need to use only one database (e.g., Genesis) and don’t want to provide or manage credentials for Zensus and Regio.
* Current implementation enforces all-or-nothing and raises if any backend is invalid.
* This PR enables a narrower setup without breaking existing callers.

**Backward compatibility**

* Fully backward compatible: the default call `setup_credentials()` continues to handle all databases.
* No changes to public constants, env var names, or file layout.

**Usage examples**

```python
# Configure only GENESIS (with validation)
from pystatis import config as cfg
cfg.setup_credentials(["genesis"])

# Configure GENESIS + REGIO
cfg.setup_credentials(["genesis", "regio"])

# Configure all (previous behavior)
cfg.setup_credentials()

# Configure only GENESIS and skip validation (e.g., offline CI)
cfg.setup_credentials(["genesis"], validate=False)
```

**Environment variables (unchanged)**

* `PYSTATIS_GENESIS_API_USERNAME` / `PYSTATIS_GENESIS_API_PASSWORD`
* `PYSTATIS_ZENSUS_API_USERNAME`  / `PYSTATIS_ZENSUS_API_PASSWORD`
* `PYSTATIS_REGIO_API_USERNAME`   / `PYSTATIS_REGIO_API_PASSWORD`

**Docs updates**

* Add:

  * “To set up only GENESIS credentials: `setup_credentials(["genesis"])`.”
